### PR TITLE
Add v0.2 and v3 latest versions to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,8 @@
             <div class="section-header">
                 <h3>Download</h3>
             </div>
-
+  <p><img src="https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdocker-hotio%2Fdocker-radarr%2Frelease%2FVERSION.json&label=Latest v0.2 Stable%20Version&style=for-the-badge&color=4051B5" alt="v0.2 current version"/></p>
+    <p><img src="https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdocker-hotio%2Fdocker-radarr%2Fnightly%2FVERSION.json&label=Latest v3 Beta Version&style=for-the-badge&color=4051B5"/></p>
             <div class="row download_wrapper">
                 <div class="col-sm-3">
                     <div class="option">


### PR DESCRIPTION
Add shield icons using hotio's builds to indicate most recent v0.2 and v3 versions