### PR TITLE
fix typos etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                         Calendar
                     </h3>
                     <p>
-                        See all your upcoming episodes in one convenient location.
+                        See all your upcoming movies in one convenient location.
                     </p>
                 </div>
             </div>
@@ -178,6 +178,9 @@
                         <a class=nav-link data-toggle=tab href=#downloads-v3-docker><i class="fab fa-docker"></i> Docker</a>
                     </li>
                     <li class=nav-item>
+                        <a class=nav-link data-toggle=tab href=#downloads-v3-bsd><i class="fab fa-linux"></i> BSD </a>
+                    </li>
+                    <li class=nav-item>
                         <a class=nav-link data-toggle=tab href=#downloads-v3-other><i class="fas fa-ellipsis-v"></i>&nbsp;&nbsp;Others</a>
                     </li>
                 </ul>
@@ -190,14 +193,14 @@
                                     Radarr is supported natively on Windows. Radarr can be installed on Windows as Windows Service or system tray application.
                                 </p>
                                 <p>
-                                    A Windows Service runs even when the user is not logged in, but special case must be taken since Windows Services cannot access network drives (\\server\share or X:\ mapped drives) without special configuration steps.<br>
-                                    It's therefore advisable to install Radarr as a system tray application if the user does not need to log out, the option to do so is provided during the installer.
+                                    A Windows Service runs even when the user is not logged in, but special care must be taken since Windows Services cannot access network drives (X:\ mapped drives) without special configuration steps.<br>
+                                    Additionally the Windows Service runs under the 'Local Service' account, by default this account does not have permissions to access your user's home directory unless permissions have been assigned manually. This is particularly relevant when using download clients that are configured to download to your home directory.<br>
+                                    It's therefore advisable to install Radarr as a system tray application if the user can remain logged in. The option to do so is provided during the installer.
                                 </p>
                                 <div class="alert alert-warning">Radarr v3 no longer supports Windows XP. At this time Windows 7 <i>should</i> still work, but we will not maintain Windows 7 support. Note that KB2533623 and Microsoft Visual C++ 2015 Redistributable Update 3 are needed to run .net core apps on Windows 7</div>
                                 <div class="alert alert-info">
                                     <h4 class=alert-heading>Radarr v0.2 migration</h4>
                                     Radarr v3 will automatically convert the existing Radarr v0.2 installation. Radarr v0.2 already used <code>C:\ProgramData\Radarr</code>, which will be automatically converted to v3 on startup.
-                                    It's advisable to make a backup of the v0.2 data first.
                                 </div>
                             </dd>
                             <dt><span class=step>1</span>Install Radarr</dt>
@@ -232,6 +235,9 @@
                                     <a class="nav-link active" data-toggle=pill href=#downloads-v3-linux-archlinux><img src=logo/archlinux.svg class="icon svg"> ArchLinux</a>
                                 </li>
                                 <li class=nav-item>
+                                    <a class=nav-link data-toggle=pill href=#downloads-v3-linux-debianubuntu><i class="fab fa-ubuntu"></i> Debian or Ubuntu</a>
+                                </li>
+                                <li class=nav-item>
                                     <a class=nav-link data-toggle=pill href=#downloads-v3-linux-other><i class="fas fa-ellipsis-v"></i>&nbsp;&nbsp;Others</a>
                                 </li>
                             </ul>
@@ -247,7 +253,7 @@
                                             <div class="alert alert-info">
                                                 <h4 class=alert-heading>Radarr v0.2 migration</h4>
                                                 The existing radarr AUR packages already used <code>/var/lib/radarr</code> to store the Radarr database.
-                                                Radarr v3 will convert that directory automatically on startup. It's advisable to make a backup of the v0.2 data first.
+                                                Radarr v3 will convert that directory automatically on startup.
                                             </div>
                                         </dd>
                                         <dt><span class=step>1</span>Install Radarr</dt>
@@ -287,6 +293,20 @@ sudo systemctl enable --now radarr</code></pre>
                                         </div>
                                     </div>
                                 </div>
+                                <div class="tab-pane fade" id=downloads-v3-linux-debianubuntu role=tabpanel>
+                                    <dl class=install-steps>
+                                        <dt>Installation</dt>
+                                        <dd>
+                                            <p>
+                                                The community has put together an <a href=https://wiki.servarr.com/Radarr_Installation#Debian.2FUbuntu>Installation Guide</a> to help you install this on Debian or Ubuntu.
+                                            </p>
+                                            <div class="alert alert-info">
+                                                <h4 class=alert-heading>Radarr v0.2 migration</h4>
+                                                Radarr v3 will convert any existing v0.2 directory automatically on startup.
+                                            </div>
+                                        </dd>
+                                    </dl>
+                                </div>
                                 <div class="tab-pane fade" id=downloads-v3-linux-other role=tabpanel>
                                     <div class=install-description>
                                         <div class="alert alert-info">
@@ -324,7 +344,6 @@ sudo systemctl enable --now radarr</code></pre>
                                     <h4 class=alert-heading>Radarr v0.2 migration</h4>
                                     The Radarr v3 package will attempt to automatically migrate an existing Radarr v0.2 database.
                                     Radarr v0.2 used the user's home directory <code>~/.config/Radarr</code> to store the application data which v3 also uses.<br>
-                                    It's advisable to make a backup of the v0.2 data before installing v3.
                                 </div>
                             </dd>
                             <dt><span class=step>1</span>Download App package</dt>
@@ -337,16 +356,13 @@ sudo systemctl enable --now radarr</code></pre>
                                     Open the archive and drag the Radarr icon to your Application folder.
                                 </p>
                                 <div class="alert alert-warning">
-                                    Radarr v3 is not compatible with OSX versions < 10.13 due to netcore compatability. </div>
+                                    Radarr v3 is not compatible with OSX versions < 10.13 (High Sierra) due to netcore incompatibilities. </div>
                             </dd>
                             <dt><span class=step>3</span>Start Radarr</dt>
                             <dd>
                                 <p>
                                     Open Radarr.app in your Application folder.
                                 </p>
-                                <div class="alert alert-info">
-                                    During startup it may ask you to install the Mono Runtime if an appropriate version is not already installed.
-                                </div>
                             </dd>
                             <dt><span class=step>4</span>View Radarr</dt>
                             <dd>
@@ -421,7 +437,7 @@ sudo systemctl enable --now radarr</code></pre>
                                 <div class="alert alert-info">
                                     <h4 class=alert-heading>Radarr v0.2 migration</h4>
                                     Most docker containers use <code>/config</code> volume to mount the data directory and supply that path to Radarr as parameter.
-                                    Radarr v3 will convert the given directory on startup if a Radarr v0.2 database is found. It's advisable to make a backup of the v0.2 data first.
+                                    Radarr v3 will convert the given directory on startup if a Radarr v0.2 database is found.
                                 </div>
                             </dd>
                             <dt><span class=step>1</span>Avoid common pitfalls</dt>
@@ -459,21 +475,38 @@ sudo systemctl enable --now radarr</code></pre>
                                     and maintenance of them will depend on the route you choose.
                                 <ul>
                                     <li>
-                                        <h5><a href=https://hub.docker.com/r/linuxserver/radarr>ghcr.io/linuxserver/radarr:latest</a></h5>
+                                        <h5><a href=https://hub.docker.com/r/hotio/radarr>hotio/radarr:release</a></h5>
                                         <p>
-                                            <a href=//www.linuxserver.io>linuxserver.io</a> is one of the most prolific and popular Docker image maintainers. They also maintain images for most of the popular download clients as well.
-                                            LinuxServer specifies a couple of default volumes such as <code>/movies</code> and <code>/downloads</code>. Our recommendation is to use a single volume for the data, as mentioned above.
+                                            <a href=https://hotio.dev>hotio</a> doesn't specify any default volumes, besides <code>/config</code>. Images are automatically updated 2x in 1 hour if upstream changes are found. Hotio also builds our Pull Requests which may be useful for testing.
+                                            Read the <a href=https://hotio.dev/containers/radarr>instructions</a> on how to install the image.
                                         </p>
                                     </li>
                                     <li>
-                                        <h5><a href=https://hub.docker.com/r/hotio/radarr>hotio/radarr:release</a></h5>
+                                        <h5><a href=https://hub.docker.com/r/linuxserver/radarr>ghcr.io/linuxserver/radarr:latest</a></h5>
                                         <p>
-                                            <a href=https://hotio.dev>hotio</a> doesn't specify any default volumes, besides <code>/config</code>. Images are automatically updated 2x in 1 hour if upstream changes are found.
-                                            Read the <a href=https://hotio.dev/containers/radarr>instructions</a> on how to install the image.
+                                            <a href=//www.linuxserver.io>linuxserver.io</a> is one of the most prolific and popular Docker image maintainers. They also maintain images for most of the popular download clients as well.
+                                            LinuxServer specifies a couple of default volumes such as <code>/movies</code> and <code>/downloads</code>. The default volumes are not optimal nor recommended. Our recommendation is to use a single volume for the data, as mentioned above.
                                         </p>
                                     </li>
                                 </ul>
                                 </p>
+                            </dd>
+                        </dl>
+                    </div>
+                    <div class="tab-pane fade" id=downloads-v3-bsd role=tabpanel>
+                        <dl class=install-steps>
+                            <dt>Installation</dt>
+                            <dd>
+                                <p>
+                                    The Radarr team provides
+                                    <a href=https://radarr.servarr.com/v1/update/master/updatefile?os=bsd&arch=x64&runtime=netcore> builds for BSD</a>.<br>
+                                    Additional details can be found on Frank's GH
+                                    <a href=https://github.com/Thefrank/freebsd-port-sooners/blob/main/Radarr_Installation_TrueNAS_GUI.md/>Link</a>
+                                </p>
+                                <div class="alert alert-info">
+                                    <h4 class=alert-heading>Radarr v0.2 migration</h4>
+                                    Radarr v3 will convert any existing v0.2 directory automatically on startup.
+                                </div>
                             </dd>
                         </dl>
                     </div>

--- a/src/sections/downloads-v3/bsd.marko
+++ b/src/sections/downloads-v3/bsd.marko
@@ -1,0 +1,11 @@
+<install-steps>
+  <install-step title="Installation">
+    <p>
+      The Radarr team provides
+      <a href="https://radarr.servarr.com/v1/update/master/updatefile?os=bsd&arch=x64&runtime=netcore"> builds for BSD</a>.<br/>
+      Additional details can be found on Frank's GH
+      <a href="https://github.com/Thefrank/freebsd-port-sooners/blob/main/Radarr_Installation_TrueNAS_GUI.md/">Link</a>
+    </p>
+    <migration-alert>Radarr v3 will convert any existing v0.2 directory automatically on startup.</migration-alert>
+  </install-step>
+</install-steps>

--- a/src/sections/downloads-v3/docker.marko
+++ b/src/sections/downloads-v3/docker.marko
@@ -6,7 +6,7 @@
         </p>
         <migration-alert>
             Most docker containers use <code>/config</code> volume to mount the data directory and supply that path to Radarr as parameter.
-            Radarr v3 will convert the given directory on startup if a Radarr v0.2 database is found. It's advisable to make a backup of the v0.2 data first.
+            Radarr v3 will convert the given directory on startup if a Radarr v0.2 database is found.
         </migration-alert>
     </install-step>
     <install-step num="1" title="Avoid common pitfalls">
@@ -42,17 +42,17 @@
             and maintenance of them will depend on the route you choose.
             <ul>
             <li>
-                <h5><a href="https://hub.docker.com/r/linuxserver/radarr">ghcr.io/linuxserver/radarr:latest</a></h5>
+                <h5><a href="https://hub.docker.com/r/hotio/radarr">hotio/radarr:release</a></h5>
                 <p>
-                    <a href="//www.linuxserver.io">linuxserver.io</a> is one of the most prolific and popular Docker image maintainers. They also maintain images for most of the popular download clients as well.
-                    LinuxServer specifies a couple of default volumes such as <code>/movies</code> and <code>/downloads</code>. Our recommendation is to use a single volume for the data, as mentioned above.
+                    <a href="https://hotio.dev">hotio</a> doesn't specify any default volumes, besides <code>/config</code>. Images are automatically updated 2x in 1 hour if upstream changes are found. Hotio also builds our Pull Requests which may be useful for testing.
+                    Read the <a href="https://hotio.dev/containers/radarr">instructions</a> on how to install the image.
                 </p>
             </li>
             <li>
-                <h5><a href="https://hub.docker.com/r/hotio/radarr">hotio/radarr:release</a></h5>
+                <h5><a href="https://hub.docker.com/r/linuxserver/radarr">ghcr.io/linuxserver/radarr:latest</a></h5>
                 <p>
-                    <a href="https://hotio.dev">hotio</a> doesn't specify any default volumes, besides <code>/config</code>. Images are automatically updated 2x in 1 hour if upstream changes are found.
-                    Read the <a href="https://hotio.dev/containers/radarr">instructions</a> on how to install the image.
+                    <a href="//www.linuxserver.io">linuxserver.io</a> is one of the most prolific and popular Docker image maintainers. They also maintain images for most of the popular download clients as well.
+                    LinuxServer specifies a couple of default volumes such as <code>/movies</code> and <code>/downloads</code>. The default volumes are not optimal nor recommended. Our recommendation is to use a single volume for the data, as mentioned above.
                 </p>
             </li>
             </ul>

--- a/src/sections/downloads-v3/downloads-v3.marko
+++ b/src/sections/downloads-v3/downloads-v3.marko
@@ -5,6 +5,7 @@
         <tabview-item href="#downloads-v3-macos" icon="fab-apple"> macOS</tabview-item>
         <tabview-item href="#downloads-v3-nas" icon="fas-hdd"> NAS</tabview-item>
         <tabview-item href="#downloads-v3-docker" icon="fab-docker"> Docker</tabview-item>
+        <tabview-item href="#downloads-v3-bsd" icon="fab-linux"> BSD </tabview-item>
         <tabview-item href="#downloads-v3-other" icon="fas-ellipsis-v">&nbsp;&nbsp;Others</tabview-item>
     </ul>
     <div class="tab-content" id="downloads-v3-tabcontent">
@@ -13,6 +14,7 @@
         <tabview-pane id="downloads-v3-macos" file="downloads-v3/macos.marko" />
         <tabview-pane id="downloads-v3-nas" file="downloads-v3/nas.marko" />
         <tabview-pane id="downloads-v3-docker" file="downloads-v3/docker.marko" />
+        <tabview-pane id="downloads-v3-bsd" file="downloads-v3/bsd.marko" />
         <tabview-pane id="downloads-v3-other">
             <alert level="info">
                 Please contact us if you wish to port Radarr v3 for any other platform that the ones already listed.<br/>

--- a/src/sections/downloads-v3/linux-archlinux.marko
+++ b/src/sections/downloads-v3/linux-archlinux.marko
@@ -6,7 +6,7 @@
         </p>
         <migration-alert>
             The existing radarr AUR packages already used <code>/var/lib/radarr</code> to store the Radarr database.
-            Radarr v3 will convert that directory automatically on startup. It's advisable to make a backup of the v0.2 data first.
+            Radarr v3 will convert that directory automatically on startup.
         </migration-alert>
     </install-step>
     <install-step num="1" title="Install Radarr">

--- a/src/sections/downloads-v3/linux-debianubuntu.marko
+++ b/src/sections/downloads-v3/linux-debianubuntu.marko
@@ -1,0 +1,10 @@
+<install-steps>
+    <install-step title="Installation">
+        <p>
+            The community has put together an <a href="https://wiki.servarr.com/Radarr_Installation#Debian.2FUbuntu">Installation Guide</a> to help you install this on Debian or Ubuntu.
+        </p>
+        <migration-alert>
+            Radarr v3 will convert any existing v0.2 directory automatically on startup.
+        </migration-alert>
+    </install-step>
+</install-steps>

--- a/src/sections/downloads-v3/linux.marko
+++ b/src/sections/downloads-v3/linux.marko
@@ -1,10 +1,12 @@
 <div>
     <ul class="nav nav-pills">
         <tabview-item active pill href="#downloads-v3-linux-archlinux" icon="./logo/archlinux.svg"> ArchLinux</tabview-item>
+        <tabview-item pill href="#downloads-v3-linux-debianubuntu" icon="fab-ubuntu"> Debian or Ubuntu</tabview-item>
         <tabview-item pill href="#downloads-v3-linux-other" icon="fas-ellipsis-v">&nbsp;&nbsp;Others</tabview-item>
     </ul>
     <div class="tab-content" id="download-v3-linux-tabcontent">
         <tabview-pane active id="downloads-v3-linux-archlinux" file="downloads-v3/linux-archlinux.marko" />
+        <tabview-pane id="downloads-v3-linux-debianubuntu" file="downloads-v3/linux-debianubuntu.marko" />
         <tabview-pane id="downloads-v3-linux-other">
             <install-description>
                 <alert level="info">

--- a/src/sections/downloads-v3/macos.marko
+++ b/src/sections/downloads-v3/macos.marko
@@ -8,7 +8,6 @@
         <migration-alert>
             The Radarr v3 package will attempt to automatically migrate an existing Radarr v0.2 database.
             Radarr v0.2 used the user's home directory <code>~/.config/Radarr</code> to store the application data which v3 also uses.<br/>
-            It's advisable to make a backup of the v0.2 data before installing v3.
         </migration-alert>
     </install-step>
     <install-step num="1" title="Download App package">
@@ -19,16 +18,13 @@
             Open the archive and drag the Radarr icon to your Application folder.
         </p>
         <alert level="warning">
-            Radarr v3 is not compatible with OSX versions < 10.13 due to netcore compatability.
+            Radarr v3 is not compatible with OSX versions < 10.13 (High Sierra) due to netcore incompatibilities.
         </alert>
     </install-step>
     <install-step num="3" title="Start Radarr">
         <p>
             Open Radarr.app in your Application folder.
         </p>
-        <alert level="info">
-            During startup it may ask you to install the Mono Runtime if an appropriate version is not already installed.
-        </alert>
     </install-step>
     <install-step num="4" title="View Radarr">
         <p>

--- a/src/sections/downloads-v3/windows.marko
+++ b/src/sections/downloads-v3/windows.marko
@@ -4,13 +4,13 @@
             Radarr is supported natively on Windows. Radarr can be installed on Windows as Windows Service or system tray application.
         </p>
         <p>
-            A Windows Service runs even when the user is not logged in, but special case must be taken since Windows Services cannot access network drives (\\server\share or X:\ mapped drives) without special configuration steps.<br/>
-            It's therefore advisable to install Radarr as a system tray application if the user does not need to log out, the option to do so is provided during the installer.
+            A Windows Service runs even when the user is not logged in, but special care must be taken since Windows Services cannot access network drives (X:\ mapped drives) without special configuration steps.<br/>
+            Additionally the Windows Service runs under the 'Local Service' account, by default this account does not have permissions to access your user's home directory unless permissions have been assigned manually. This is particularly relevant when using download clients that are configured to download to your home directory.<br/>
+            It's therefore advisable to install Radarr as a system tray application if the user can remain logged in. The option to do so is provided during the installer.
         </p>
         <alert level="warning">Radarr v3 no longer supports Windows XP. At this time Windows 7 <i>should</i> still work, but we will not maintain Windows 7 support. Note that KB2533623 and Microsoft Visual C++ 2015 Redistributable Update 3 are needed to run .net core apps on Windows 7</alert>
         <migration-alert>
             Radarr v3 will automatically convert the existing Radarr v0.2 installation. Radarr v0.2 already used <code>C:\ProgramData\Radarr</code>, which will be automatically converted to v3 on startup.
-            It's advisable to make a backup of the v0.2 data first.
         </migration-alert>
     </install-step>
     <install-step num="1" title="Install Radarr">

--- a/src/sections/features.marko
+++ b/src/sections/features.marko
@@ -8,7 +8,7 @@
             Calendar
         </h3>
         <p>
-            See all your upcoming episodes in one convenient location.
+            See all your upcoming movies in one convenient location.
         </p>
     </div>
 </div>


### PR DESCRIPTION
various typos; add Mac OSX name; remove backup v0.2 db (v3 auto does)

Closes #17 